### PR TITLE
Add support for DISABLE_NOTIFICATIONS param

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Note test data is created with current timestamps, so if you see "Found 0 holdsh
 AWS_PROFILE=nypl-digital-dev ENVIRONMENT=development python create_test_data.py
 ```
 
+To disable notifications (i.e. to test Sierra connection or run the poller in a "dry run" mode), add `DISABLE_NOTIFICATIONS=true`
+
 ## Contributing
 
 This repo uses the [Main-QA-Production Git Workflow](https://github.com/NYPL/engineering-general/blob/main/standards/git-workflow.md#main-qa-production)


### PR DESCRIPTION
We need to be able to configure the poller to run in a "dry run" mode where it connects to Sierra, identifies holdshelf events, logs the number found, but doesn't attempt to hit the PatronServices Notify endpoint or update Redis. This will aid connection debugging, allow us to deploy and run the poller regardless of PatronServices Notify app state, and give us a kill switch should we need to disable notifications.