### PR TITLE
Update to  new PatronServices contract, add production deployment

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -39,4 +39,25 @@ jobs:
         run: |
           terraform -chdir=provisioning/qa init -input=false
           terraform -chdir=provisioning/qa apply -auto-approve -input=false
+  deploy-production:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/production'
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::946183545209:role/GithubActionsDeployerRole
+          aws-region: us-east-1
+      - uses: actions/checkout@v3
+      - name: Package app
+        run: provisioning/package.sh
+      - uses: hashicorp/setup-terraform@v2
+      - name: Deploy app to Production
+        run: |
+          terraform -chdir=provisioning/production init -input=false
+          terraform -chdir=provisioning/production apply -auto-approve -input=false
 

--- a/lib/poller.py
+++ b/lib/poller.py
@@ -58,7 +58,7 @@ class Poller:
 
         for entry in entries:
             path = 'patrons/{}/notify'.format(entry['patron_id'])
-            payload = {'type': 'hold-ready', 'holdId': entry['hold_id']}
+            payload = {'type': 'hold-ready', 'sierraHoldId': entry['hold_id']}
 
             # Post to PatronServices notify endpoint:
             resp = None

--- a/provisioning/base/resources.tf
+++ b/provisioning/base/resources.tf
@@ -20,7 +20,7 @@ variable "vpc_config" {
 
 # Upload the zipped app to S3:
 resource "aws_s3_object" "uploaded_zip" {
-  bucket = "nypl-travis-builds-${var.environment}"
+  bucket = "nypl-github-actions-builds-${var.environment}"
   key    = "holdshelf-poller-${var.environment}-dist.zip"
   acl    = "private"
   source = "../../build/build.zip"

--- a/provisioning/package.sh
+++ b/provisioning/package.sh
@@ -1,4 +1,4 @@
-rm -r build
+rm -rf build
 
 # Build dependencies:
 pip install -r requirements.txt --target ./build

--- a/provisioning/production/resources.tf
+++ b/provisioning/production/resources.tf
@@ -6,7 +6,7 @@ provider "aws" {
 terraform {
   # Use s3 to store terraform state
   backend "s3" {
-    bucket  = "nypl-travis-builds-production"
+    bucket  = "nypl-github-actions-builds-production"
     key     = "holdshelf-poller-terraform-state"
     region  = "us-east-1"
   }

--- a/provisioning/qa/resources.tf
+++ b/provisioning/qa/resources.tf
@@ -5,7 +5,7 @@ provider "aws" {
 terraform {
   # Use s3 to store terraform state
   backend "s3" {
-    bucket  = "nypl-travis-builds-qa"
+    bucket  = "nypl-github-actions-builds-qa"
     key     = "holdshelf-poller-terraform-state"
     region  = "us-east-1"
   }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/tests/unit/test_poller.py
+++ b/tests/unit/test_poller.py
@@ -75,7 +75,7 @@ class TestPoller:
 
         # Verify we post to PatronServices Notify endpoint:
         platform_api_client_post.assert_called_once_with(
-                'patrons/9001/notify', {'holdId': 1, 'type': 'hold-ready'})
+                'patrons/9001/notify', {'sierraHoldId': 1, 'type': 'hold-ready'})
         # Verify we record hold processed in Redis:
         redis_set_hold_processed.assert_called_once_with(mock_holds[0])
 
@@ -86,6 +86,6 @@ class TestPoller:
 
         # Verify we post to PatronServices Notify endpoint:
         platform_api_client_post_failed.assert_called_once_with(
-                'patrons/9001/notify', {'holdId': 1, 'type': 'hold-ready'})
+                'patrons/9001/notify', {'sierraHoldId': 1, 'type': 'hold-ready'})
         # Verify we DO NOT record hold processed in Redis:
         redis_set_hold_processed.assert_not_called()


### PR DESCRIPTION
* Updates PatronServices integration to use sierraHoldId instead of
deprecated "holdId"
* Add production deployment
* Add flake8 config to increase line length to 120 because what year is this