### PR TITLE
Add M1 location codes for dry-run

### DIFF
--- a/config/production.yaml
+++ b/config/production.yaml
@@ -1,7 +1,7 @@
 ---
 PLAINTEXT_VARIABLES:
     AGE_OF_HOLDS_TO_QUERY_HOURS: 72
-    HOLDING_LOCATION_CODES: mal92,mal98,mal99,mag92,maf92,maf98,maf99,mas92,map92,map98
+    HOLDING_LOCATION_CODES: mal92,mal98,mal99,mag92,maf92,maf98,maf99,mas92,map92,map98,mab82,mab88,maf82,mag82,mai82,mal82,mab88,mas82,map82
     LOG_LEVEL: info
     NYPL_API_BASE_URL: https://platform.nypl.org/api/v0.1
     NYPL_API_TOKEN_URL: https://isso.nypl.org/oauth/token

--- a/config/qa.yaml
+++ b/config/qa.yaml
@@ -1,7 +1,7 @@
 ---
 PLAINTEXT_VARIABLES:
     AGE_OF_HOLDS_TO_QUERY_HOURS: 72
-    HOLDING_LOCATION_CODES: mal92,mal98,mal99,mag92,maf92,maf98,maf99,mas92,map92,map98
+    HOLDING_LOCATION_CODES: mal92,mal98,mal99,mag92,maf92,maf98,maf99,mas92,map92,map98,mab82,mab88,maf82,mag82,mai82,mal82,mab88,mas82,map82
     LOG_LEVEL: info
     NYPL_API_BASE_URL: https://qa-platform.nypl.org/api/v0.1
     NYPL_API_TOKEN_URL: https://isso.nypl.org/oauth/token


### PR DESCRIPTION
This adds M1 locations to `HOLDING_LOCATION_CODES` to ensure that holdshelf events detected for items in M1 sent to Rose trigger a hold-ready notification for the requesting patron.

I believe we want this for the dry run

https://jira.nypl.org/browse/SCC-3698