### PR TITLE
Scc 3961

### DIFF
--- a/lib/poller.py
+++ b/lib/poller.py
@@ -111,6 +111,8 @@ class Poller:
 
             # Post to PatronServices notify endpoint:
             resp = None
+            content = str(resp.content)
+            index = content.find('Unable to find patron email')
             try:
                 resp = self.platform_client.post(path, payload)
             except HTTPError as e:
@@ -120,7 +122,7 @@ class Poller:
             if resp and resp.status_code == 200:
                 # Mark hold as processed:
                 self.redis_client.set_hold_processed(entry)
-            elif resp and resp.status_code == 400 and str(resp.content).find('Unable to find patron email') > -1:
+            elif resp and resp.status_code == 400 and index > -1:
                 # If the notification fails because the patron is missing an email,
                 # log the issue but do not retry
                 self.logger.warning('Unexpected response from PatronServices'
@@ -128,8 +130,7 @@ class Poller:
                                     + f' => {resp.status_code} {resp.content}')
                 self.redis_client.set_hold_processed(entry)
             elif resp is not None:
-                content = str(resp.content)
-                index = content.find('Unable to find patron email')
+
                 self.logger.error('Unexpected response from PatronServices'
                                   + f' notify endpoint for {path} {payload}'
                                   + f' => {resp.status_code} {resp.content}'

--- a/lib/poller.py
+++ b/lib/poller.py
@@ -111,13 +111,13 @@ class Poller:
 
             # Post to PatronServices notify endpoint:
             resp = None
-            content = str(resp.content)
-            index = content.find('Unable to find patron email')
             try:
                 resp = self.platform_client.post(path, payload)
             except HTTPError as e:
                 resp = e.response
 
+            content = str(resp.content)
+            index = content.find('Unable to find patron email')
             # Assert 200 response:
             if resp and resp.status_code == 200:
                 # Mark hold as processed:

--- a/lib/poller.py
+++ b/lib/poller.py
@@ -128,10 +128,9 @@ class Poller:
                                     + f' => {resp.status_code} {resp.content}')
                 self.redis_client.set_hold_processed(entry)
             elif resp is not None:
-
                 self.logger.error('Unexpected response from PatronServices'
                                   + f' notify endpoint for {path} {payload}'
-                                  + f' => {resp.status_code} {resp.content}'
+                                  + f' => {resp.status_code} {resp.content}')
             else:
                 self.logger.error('No response from PatronServices'
                                   + f' notify endpoint for {path} {payload}')

--- a/lib/poller.py
+++ b/lib/poller.py
@@ -122,8 +122,9 @@ class Poller:
                 self.redis_client.set_hold_processed(entry)
             # If the notification fails because the patron is missing an email,
             # log the issue but do not retry
-            elif resp.status_code == 400 and str(resp.content).find('Unable to find patron email') > -1:
-                self.logger.warning('Unexpected response from PatronServices'
+            elif resp is not None and resp.status_code == 400 \
+                    and str(resp.content).find('Unable to find patron email') > -1:
+                self.logger.warning('Got no-email response from PatronServices'
                                     + f' notify endpoint for {path} {payload}'
                                     + f' => {resp.status_code} {resp.content}')
                 self.redis_client.set_hold_processed(entry)

--- a/lib/poller.py
+++ b/lib/poller.py
@@ -128,10 +128,16 @@ class Poller:
                                     + f' => {resp.status_code} {resp.content}')
                 self.redis_client.set_hold_processed(entry)
             elif resp is not None:
+                content = str(resp.content)
+                index = content.find('Unable to find patron email')
                 self.logger.error('Unexpected response from PatronServices'
                                   + f' notify endpoint for {path} {payload}'
                                   + f' => {resp.status_code} {resp.content}'
-                                  + f' debugging: {type(resp.status_code)}, {resp.status_code}, {resp.status_code == 400}, {type(resp.content)}, {resp.content}, {str(resp.content).find('Unable to find patron email')}')
+                                  + ' debugging: '
+                                  + f'{type(resp.status_code)}, {resp.status_code}, {resp.status_code == 400}, '
+                                  + f' {type(resp.content)}, {resp.content}, '
+                                  + f' {str(resp.content)} '
+                                  + f' {index}')
             else:
                 self.logger.error('No response from PatronServices'
                                   + f' notify endpoint for {path} {payload}')

--- a/lib/poller.py
+++ b/lib/poller.py
@@ -130,7 +130,8 @@ class Poller:
             elif resp is not None:
                 self.logger.error('Unexpected response from PatronServices'
                                   + f' notify endpoint for {path} {payload}'
-                                  + f' => {resp.status_code} {resp.content}')
+                                  + f' => {resp.status_code} {resp.content}'
+                                  + f' debugging: {type(resp.status_code)}, {resp.status_code}, {resp.status_code == 400}, {type(resp.content)}, {resp.content}, {str(resp.content).find('Unable to find patron email')}')
             else:
                 self.logger.error('No response from PatronServices'
                                   + f' notify endpoint for {path} {payload}')


### PR DESCRIPTION
- Remove check for `resp` to be truthy in case of 400, since HTTPError content is apparently falsey